### PR TITLE
Use `is` to compare type of objects (#50)

### DIFF
--- a/userge/plugins/help.py
+++ b/userge/plugins/help.py
@@ -484,7 +484,7 @@ if userge.has_bot:
         if not media_:
             return
         MEDIA_TYPE = type_
-        if type(media_) == str:
+        if type(media_) is str:
             limit = 1 if type_ == "url_gif" else 5
             media_info = MediaInfo.parse(media_)
             for track in media_info.tracks:


### PR DESCRIPTION
Co-authored-by: deepsource-autofix[bot] <62050782+deepsource-autofix[bot]@users.noreply.github.com>